### PR TITLE
fix: 修复homework3 t.throws参数格式问题

### DIFF
--- a/homework/3/eval.test.js
+++ b/homework/3/eval.test.js
@@ -27,7 +27,7 @@ test('声明 - 初级挑战', t => {
     if (err === undefined) {
       t.deepEqual(customerEval(sourceCode), undefined)
     } else {
-      t.throws(() => customerEval(sourceCode), err)
+      t.throws(() => customerEval(sourceCode), { instanceOf: err.constructor, message: err.message })
     }
   }
 })


### PR DESCRIPTION
回坑遇到ava报错，查文档刚更新过qwq
![GLJ083CZ5JE(1O2@03Y8V 4](https://user-images.githubusercontent.com/69080784/172601270-83a8a947-b38d-4132-a0da-78d36c0d9a08.png)
![image](https://user-images.githubusercontent.com/69080784/172601240-de1bcc99-7636-482a-98f5-7f5325dcbf22.png)

