### PR TITLE
fix: 修复 homework-3 测试用例

### DIFF
--- a/homework/3/eval.test.js
+++ b/homework/3/eval.test.js
@@ -21,7 +21,10 @@ test('声明 - 初级挑战', t => {
   const sourceCodeErrorMap = {
     'var a = 1;let b = 2;const c = 3': undefined,
     'var a = 1; var a = 2;': undefined,
-    'const a = 1; a = 5;': new TypeError('Assignment to constant variable'),
+    'const a = 1; a = 5;': {
+      message: 'Assignment to constant variable',
+      instanceOf: TypeError,
+    },
   }
   for (const [sourceCode, err] of Object.entries(sourceCodeErrorMap)) {
     if (err === undefined) {


### PR DESCRIPTION
运行 homework-3， 声明 - 初级挑战， const a = 1; a = 5;用例时，ava 会出现报错：

The second argument to `t.throws()` must be an expectation object, `null` or `undefined`

[ava](https://github.com/avajs/ava/blob/e387cba63ccf1a24a96b2375d61738ca38f48082/test-tap/assert.js) 测试用例说明了expectation object是什么，需要传入以下格式的对象：

```
 {
      message: 'Assignment to constant variable',
      instanceOf: TypeError,
    },
```